### PR TITLE
Account for states_provinces in third_party_search_index()

### DIFF
--- a/third_party/reegion_select/ft.reegion_select.php
+++ b/third_party/reegion_select/ft.reegion_select.php
@@ -275,7 +275,8 @@ class Reegion_select_ft extends EE_Fieldtype {
 			case 'provinces':
 				$r .= ' ' . $provinces[$data];
 				break;
-		 	case 'provinces_states':
+			case 'provinces_states':
+			case 'states_provinces':
 				$regions = array_merge($provinces, $states);
 				$r .= ' ' . $regions[$data];
 				break;


### PR DESCRIPTION
The state/country name wasn't added to the index for this setting.